### PR TITLE
[PR MIRROR]: Fixes cargo shuttle ids

### DIFF
--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -311,10 +311,11 @@
 		shuttle_id[template] = idnum = 1
 	else
 		idnum = shuttle_id[template]++
-	if(id == initial(id))
-		id = "[id][idnum]"
-	if(name == initial(name) && idnum > 1)
-		name = "[name] [idnum]"
+	if(idnum > 1)
+		if(id == initial(id))
+			id = "[id][idnum]"
+		if(name == initial(name))
+			name = "[name] [idnum]"
 	for(var/i in shuttle_areas)
 		var/area/place = i
 		for(var/obj/machinery/computer/shuttle/comp in place)


### PR DESCRIPTION
Original Author: ninjanomnom
Original PR Link: https://github.com/tgstation/tgstation/pull/39390

:cl: ninjanomnom
fix: The cargo shuttle should move normally again
/:cl:

And anything else that uses a console external to the shuttle itself