### PR TITLE
[PR MIRROR]: Makes blood contract work only for people inside of your view range.

### DIFF
--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -992,7 +992,7 @@
 	used = TRUE
 
 	var/list/da_list = list()
-    for(var/mob/living/M in view(src, 7))
+	for(var/mob/living/M in view(src, 7))
     	if(ishuman(M) && M.client))
         	da_list[M.real_name] = M
 

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -992,9 +992,9 @@
 	used = TRUE
 
 	var/list/da_list = list()
-	for(var/I in GLOB.alive_mob_list & GLOB.player_list)
-		var/mob/living/L = I
-		da_list[L.real_name] = L
+    for(var/mob/living/M in view(src, 7))
+    	if(ishuman(M) && M.client))
+        	da_list[M.real_name] = M
 
 	var/choice = input(user,"Who do you want dead?","Choose Your Victim") as null|anything in da_list
 


### PR DESCRIPTION
Original Author: evsey9
Original PR Link: https://github.com/tgstation/tgstation/pull/39387

:cl: Evsey9
balance: Blood Contract now only works on people that are inside of your view range.
/:cl:
I would prefer removing this item outright, but this at least makes it more sane.
This item, in it's current state, allows you to metagame the roundtype and also possible fuck over that roundtype. This item makes it incredibly easy to fuck over anyone and pit the entire station against them, whenever you want to, from wherever you want to. Gated behind PvE that could be done in a few minutes after roundstart.

Now this fixes the metagaming issue and the issue where you could pit the entirety of station on someone from whenever you wanted to.