### PR TITLE
[PR MIRROR]: Spruces up Meta circuitry lab, adds mining station restroom

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -75742,10 +75742,6 @@
 /obj/machinery/vr_sleeper,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
-"evy" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/space)
 "eEe" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -75914,11 +75910,6 @@
 /obj/machinery/vending/cigarette,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
-"hiz" = (
-/turf/open/floor/plasteel/purple/corner{
-	dir = 1
-	},
-/area/science/circuit)
 "hkq" = (
 /turf/open/floor/plasteel/caution/corner,
 /area/engine/storage_shared)
@@ -76081,8 +76072,11 @@
 /obj/item/integrated_electronics/debugger,
 /obj/item/integrated_electronics/wirer,
 /obj/structure/table/reinforced,
-/turf/open/floor/plasteel/whitepurple/side{
-	dir = 5
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/purple/side{
+	dir = 8
 	},
 /area/science/circuit)
 "kfu" = (
@@ -76242,9 +76236,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/server)
-"mfY" = (
-/turf/open/space,
-/area/space/nearstation)
 "mjJ" = (
 /obj/machinery/nuclearbomb/beer{
 	pixel_x = 2;
@@ -76252,6 +76243,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"mps" = (
+/obj/structure/lattice,
+/obj/structure/grille/broken,
+/turf/open/space/basic,
+/area/space/nearstation)
 "msD" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -76361,8 +76357,9 @@
 /turf/open/floor/plasteel,
 /area/science/circuit)
 "obJ" = (
-/turf/open/floor/plasteel/whitepurple/side{
-	dir = 6
+/turf/open/floor/plasteel/purple/corner{
+	icon_state = "purplecorner";
+	dir = 1
 	},
 /area/science/circuit)
 "obX" = (
@@ -76501,8 +76498,8 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/structure/table/reinforced,
-/turf/open/floor/plasteel/whitepurple/side{
-	dir = 4
+/turf/open/floor/plasteel/purple/side{
+	dir = 8
 	},
 /area/science/circuit)
 "pMX" = (
@@ -76739,14 +76736,6 @@
 "sJW" = (
 /turf/closed/wall/mineral/plastitanium,
 /area/engine/break_room)
-"sRC" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/purple/corner{
-	dir = 8
-	},
-/area/science/circuit)
 "tih" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
@@ -76764,11 +76753,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"twK" = (
-/turf/open/floor/plasteel/purple/side{
-	dir = 8
-	},
-/area/science/circuit)
 "tDM" = (
 /obj/machinery/door/airlock/engineering/glass/critical{
 	heat_proof = 1;
@@ -76881,7 +76865,6 @@
 /area/science/circuit)
 "uWb" = (
 /obj/structure/grille/broken,
-/obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
 "uYk" = (
@@ -115307,7 +115290,7 @@ ciL
 cgs
 csc
 dvY
-evy
+dxk
 krD
 lsv
 llb
@@ -115827,7 +115810,7 @@ jNV
 jOj
 pGw
 obJ
-hiz
+noG
 noG
 aaa
 aaa
@@ -116081,11 +116064,11 @@ dvY
 aaf
 krD
 krD
-sRC
-twK
-hiz
+krD
+krD
 noG
 noG
+aaa
 aaa
 aaa
 aaa
@@ -116335,13 +116318,13 @@ cpM
 crc
 aaf
 ctl
-aaa
-aaa
-krD
-krD
-noG
-noG
-noG
+lMJ
+lMJ
+lMJ
+lMJ
+lMJ
+lMJ
+lMJ
 aaa
 aaf
 lMJ
@@ -116593,17 +116576,17 @@ crd
 ack
 ack
 aaf
+aav
+aav
 aaf
-aaf
-aaf
-aaf
-aaf
-aaf
+anT
+anT
+anT
 aaf
 lMJ
 aaa
-aaa
-mfY
+lMJ
+aaf
 aaf
 aaf
 anT
@@ -116850,17 +116833,17 @@ cre
 aaa
 ack
 aaa
-aaf
+aav
 aaa
 aaa
-kCz
-kCz
-kCz
+aaa
+aaa
+aaa
 uWb
 kCz
+mps
 kCz
 kCz
-lMJ
 aaf
 aaa
 aqB

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -58123,14 +58123,12 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cud" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/machinery/disposal/bin,
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whitepurple/side{
+	dir = 8
+	},
 /area/science/circuit)
 "cue" = (
 /obj/structure/cable{
@@ -59088,11 +59086,11 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cwd" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/white,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/whitepurple/corner{
+	dir = 4
+	},
 /area/science/circuit)
 "cwe" = (
 /obj/structure/cable,
@@ -59934,6 +59932,9 @@
 /area/science/circuit)
 "cxP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -74377,13 +74378,6 @@
 	},
 /turf/open/floor/plating,
 /area/chapel/main)
-"dka" = (
-/obj/structure/noticeboard{
-	dir = 1;
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel/white,
-/area/science/circuit)
 "dlI" = (
 /turf/closed/wall/r_wall,
 /area/engine/supermatter)
@@ -75666,7 +75660,9 @@
 /area/maintenance/starboard/fore)
 "dGH" = (
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whitepurple/side{
+	dir = 10
+	},
 /area/science/circuit)
 "dIs" = (
 /obj/machinery/door/airlock/external{
@@ -75722,16 +75718,19 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "eqq" = (
-/obj/item/screwdriver,
-/obj/structure/table/reinforced,
-/obj/structure/sign/poster/official/random{
-	pixel_y = 32
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-10"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/machinery/requests_console{
+	department = "Science";
+	departmentType = 2;
+	dir = 2;
+	name = "Science Requests Console";
+	pixel_y = 30;
+	receive_ore_updates = 1
 	},
-/obj/item/stack/sheet/metal/ten,
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/caution/stand_clear/white,
+/turf/open/floor/plasteel/purple/side,
 /area/science/circuit)
 "eqG" = (
 /obj/effect/turf_decal/stripes/line{
@@ -75748,8 +75747,8 @@
 /turf/open/floor/plating,
 /area/space)
 "eEe" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
@@ -75789,7 +75788,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/purple/corner{
+	dir = 4
+	},
 /area/science/circuit)
 "fFM" = (
 /obj/structure/cable/yellow{
@@ -75799,9 +75800,9 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 10
+	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/purple/corner,
 /area/science/circuit)
 "fHj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -75819,7 +75820,12 @@
 /obj/item/radio/intercom{
 	pixel_y = -30
 	},
-/turf/open/floor/plasteel/white,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/purple/side{
+	dir = 1
+	},
 /area/science/circuit)
 "gqA" = (
 /obj/machinery/button/door{
@@ -75860,6 +75866,7 @@
 /obj/structure/chair/office/light{
 	dir = 1
 	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "gHh" = (
@@ -75884,12 +75891,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"gRS" = (
-/obj/structure/table/reinforced,
-/obj/item/integrated_electronics/analyzer,
-/obj/item/integrated_circuit_printer,
-/turf/open/floor/plasteel/white,
-/area/science/circuit)
 "gXY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -75901,6 +75902,11 @@
 	dir = 8
 	},
 /area/engine/storage_shared)
+"hdU" = (
+/turf/open/floor/plasteel/purple/side{
+	dir = 1
+	},
+/area/science/circuit)
 "hfn" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -75908,6 +75914,11 @@
 /obj/machinery/vending/cigarette,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
+"hiz" = (
+/turf/open/floor/plasteel/purple/corner{
+	dir = 1
+	},
+/area/science/circuit)
 "hkq" = (
 /turf/open/floor/plasteel/caution/corner,
 /area/engine/storage_shared)
@@ -75941,6 +75952,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
+"imj" = (
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plasteel/whitepurple/side,
+/area/science/circuit)
 "ioI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -76001,12 +76016,12 @@
 /area/crew_quarters/fitness/recreation)
 "jyv" = (
 /obj/structure/table/reinforced,
-/obj/item/stock_parts/cell/high,
-/obj/item/stock_parts/cell/high,
-/obj/machinery/computer/security/telescreen/circuitry{
-	pixel_x = 30
+/obj/structure/sign/poster/random{
+	pixel_y = 32
 	},
-/turf/open/floor/plasteel/white,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/multitool,
+/turf/open/floor/plasteel/purple/side,
 /area/science/circuit)
 "jyQ" = (
 /obj/structure/cable{
@@ -76037,17 +76052,42 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
-/turf/open/floor/plasteel/white,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/plasteel/purple/corner{
+	dir = 8
+	},
+/area/science/circuit)
+"jNV" = (
+/obj/structure/table/reinforced,
+/obj/item/stock_parts/cell/high,
+/obj/item/stock_parts/cell/high,
+/obj/machinery/computer/security/telescreen/circuitry{
+	pixel_y = 30
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/purple/corner{
+	dir = 8
+	},
+/area/science/circuit)
+"jOj" = (
+/obj/item/integrated_electronics/analyzer,
+/obj/item/integrated_electronics/debugger,
+/obj/item/integrated_electronics/wirer,
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/whitepurple/side{
+	dir = 5
+	},
 /area/science/circuit)
 "kfu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "krD" = (
@@ -76062,9 +76102,13 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "kxk" = (
-/obj/structure/table/reinforced,
-/obj/machinery/cell_charger,
-/turf/open/floor/plasteel/white,
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/auto_name/west{
+	pixel_x = -25
+	},
+/turf/open/floor/plasteel/stairs/left,
 /area/science/circuit)
 "kys" = (
 /obj/structure/cable/yellow{
@@ -76096,6 +76140,11 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
+"kCz" = (
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/open/space/basic,
+/area/space/nearstation)
 "kDM" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -76112,10 +76161,10 @@
 /obj/item/multitool,
 /obj/item/screwdriver,
 /obj/structure/table/reinforced,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/machinery/computer/security/telescreen/circuitry{
+	pixel_y = 30
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/purple/side,
 /area/science/circuit)
 "kVo" = (
 /obj/structure/cable/yellow{
@@ -76129,6 +76178,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/structure/sign/poster/random{
+	pixel_x = -32
+	},
 /turf/open/floor/plasteel,
 /area/science/circuit)
 "llb" = (
@@ -76137,25 +76189,20 @@
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "lsv" = (
-/obj/machinery/power/apc{
-	areastring = "/area/science/circuit";
-	dir = 1;
-	name = "Circuitry Lab APC";
-	pixel_y = 30
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
 /obj/structure/table/reinforced,
-/obj/item/multitool,
-/turf/open/floor/plasteel/white,
+/obj/item/stack/sheet/metal/ten,
+/obj/item/screwdriver,
+/turf/open/floor/plasteel/purple/side,
 /area/science/circuit)
 "lzk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/white,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/whitepurple/side{
+	dir = 4
+	},
 /area/science/circuit)
 "lGS" = (
 /obj/docking_port/stationary/public_mining_dock,
@@ -76178,6 +76225,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"lQw" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/plasteel/white,
+/area/science/circuit)
 "lWY" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Telecomms Server Room"
@@ -76191,6 +76242,9 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/server)
+"mfY" = (
+/turf/open/space,
+/area/space/nearstation)
 "mjJ" = (
 /obj/machinery/nuclearbomb/beer{
 	pixel_x = 2;
@@ -76216,7 +76270,12 @@
 	dir = 1;
 	pixel_y = -24
 	},
-/turf/open/floor/plasteel/white,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/purple/side{
+	dir = 1
+	},
 /area/science/circuit)
 "mzU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -76224,6 +76283,16 @@
 	},
 /turf/open/floor/plasteel/caution/corner,
 /area/engine/storage_shared)
+"mTj" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/purple/side{
+	dir = 1
+	},
+/area/science/circuit)
 "mWg" = (
 /obj/structure/girder,
 /obj/structure/grille,
@@ -76238,19 +76307,6 @@
 	},
 /turf/open/floor/plating,
 /area/engine/break_room)
-"nnK" = (
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/structure/table/reinforced,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 32
-	},
-/turf/open/floor/plasteel/white,
-/area/science/circuit)
 "noG" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -76304,6 +76360,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/circuit)
+"obJ" = (
+/turf/open/floor/plasteel/whitepurple/side{
+	dir = 6
+	},
+/area/science/circuit)
 "obX" = (
 /obj/docking_port/stationary{
 	area_type = /area/construction/mining/aux_base;
@@ -76323,21 +76384,15 @@
 	dir = 1
 	},
 /obj/structure/table/reinforced,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/item/stock_parts/cell/high,
 /obj/item/stock_parts/cell/high,
-/obj/machinery/computer/security/telescreen/circuitry{
-	pixel_y = 30
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/purple/side,
 /area/science/circuit)
 "ohj" = (
-/obj/item/integrated_electronics/analyzer,
-/obj/item/integrated_electronics/debugger,
-/obj/item/integrated_electronics/wirer,
-/obj/structure/table/reinforced,
+/obj/structure/chair/office/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "oub" = (
@@ -76364,19 +76419,11 @@
 /area/engine/storage_shared)
 "oLW" = (
 /obj/structure/table/reinforced,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/requests_console{
-	department = "Science";
-	departmentType = 2;
-	dir = 2;
-	name = "Science Requests Console";
-	pixel_y = 30;
-	receive_ore_updates = 1
-	},
 /obj/item/integrated_electronics/debugger,
-/turf/open/floor/plasteel/white,
+/obj/structure/sign/poster/random{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/purple/side,
 /area/science/circuit)
 "oRL" = (
 /obj/docking_port/stationary{
@@ -76396,6 +76443,9 @@
 	},
 /obj/item/paper_bin,
 /obj/item/pen,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "oZg" = (
@@ -76447,6 +76497,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"pGw" = (
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/whitepurple/side{
+	dir = 4
+	},
+/area/science/circuit)
 "pMX" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -76489,12 +76547,29 @@
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel,
 /area/engine/storage_shared)
+"qgv" = (
+/obj/machinery/light,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/turf/open/floor/plasteel/purple/side{
+	dir = 1
+	},
+/area/science/circuit)
 "qhe" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"qle" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/whitepurple/side,
+/area/science/circuit)
 "qqg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
@@ -76528,7 +76603,16 @@
 	dir = 1;
 	network = list("ss13","rd")
 	},
-/turf/open/floor/plasteel/white,
+/obj/structure/noticeboard{
+	dir = 1;
+	pixel_y = -32
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/purple/side{
+	dir = 1
+	},
 /area/science/circuit)
 "qVR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -76629,7 +76713,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
-/area/science/circuit)
+/area/maintenance/starboard/aft)
 "sGh" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -76655,6 +76739,22 @@
 "sJW" = (
 /turf/closed/wall/mineral/plastitanium,
 /area/engine/break_room)
+"sRC" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/purple/corner{
+	dir = 8
+	},
+/area/science/circuit)
+"tih" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/stairs/right,
+/area/science/circuit)
 "tsx" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -76664,11 +76764,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"txj" = (
-/obj/structure/chair/office/light{
-	dir = 1
+"twK" = (
+/turf/open/floor/plasteel/purple/side{
+	dir = 8
 	},
-/turf/open/floor/plasteel/white,
 /area/science/circuit)
 "tDM" = (
 /obj/machinery/door/airlock/engineering/glass/critical{
@@ -76687,6 +76786,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
+"tSU" = (
+/turf/open/floor/plasteel/whitepurple/side{
+	dir = 8
+	},
+/area/science/circuit)
 "tVY" = (
 /obj/structure/closet/crate,
 /obj/item/target/alien,
@@ -76768,18 +76872,25 @@
 /area/science/research)
 "uTS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+	dir = 9
 	},
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-10"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"uWb" = (
+/obj/structure/grille/broken,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "uYk" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/purple/side{
+	dir = 1
+	},
 /area/science/circuit)
 "vgd" = (
 /obj/item/taperecorder,
@@ -76820,6 +76931,9 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space)
+"vXM" = (
+/turf/open/floor/plasteel/whitepurple/side,
+/area/science/circuit)
 "wgw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
@@ -76872,6 +76986,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "wPB" = (
@@ -76891,6 +77008,10 @@
 "xkG" = (
 /obj/item/integrated_electronics/wirer,
 /obj/structure/table/reinforced,
+/obj/item/integrated_electronics/analyzer{
+	pixel_x = -4;
+	pixel_y = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "xse" = (
@@ -76948,7 +77069,12 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = -32
 	},
-/turf/open/floor/plasteel/white,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/purple/side{
+	dir = 1
+	},
 /area/science/circuit)
 "ybn" = (
 /obj/structure/chair/comfy/brown,
@@ -76975,8 +77101,14 @@
 /turf/open/floor/plasteel,
 /area/science/circuit)
 "ykE" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/white,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/cell_charger,
+/turf/open/floor/plasteel/purple/side{
+	dir = 1
+	},
 /area/science/circuit)
 
 (1,1,1) = {"
@@ -113382,7 +113514,7 @@ upN
 cxN
 cxN
 qJZ
-cxO
+uYk
 krD
 czG
 cAN
@@ -113635,9 +113767,9 @@ cuZ
 fFM
 cud
 kxk
-cxO
-cxO
-cxO
+tSU
+tSU
+tSU
 dGH
 mzh
 krD
@@ -113891,11 +114023,11 @@ cqY
 cuZ
 jLY
 lzk
-lzk
+tih
 cwd
 kfu
 cxP
-cxO
+vXM
 gnZ
 krD
 czI
@@ -114150,9 +114282,9 @@ cuZ
 obb
 krD
 kOt
-gRS
+llb
 oUA
-cxO
+vXM
 qRM
 krD
 aaf
@@ -114409,9 +114541,9 @@ krD
 oLW
 gGT
 wPk
-dGH
-dka
-krD
+vXM
+uYk
+noG
 aaf
 aaa
 aaf
@@ -114665,10 +114797,10 @@ lMz
 krD
 ocT
 xkG
-uTS
-cxO
+wPk
+vXM
 ykE
-krD
+noG
 aaa
 aaa
 aaa
@@ -114921,10 +115053,10 @@ dvY
 mjJ
 krD
 eqq
-llb
+lQw
 uTS
-cxO
-cxO
+vXM
+qgv
 krD
 aaa
 aaa
@@ -115178,10 +115310,10 @@ dvY
 evy
 krD
 lsv
-txj
+llb
 eEe
-cxO
-cxO
+qle
+mTj
 krD
 aaa
 aaa
@@ -115432,14 +115564,14 @@ cpK
 ciL
 csc
 dvY
-vLD
+lMJ
 krD
 jyv
 ohj
-nnK
 cxO
-cxO
-krD
+imj
+hdU
+noG
 aaa
 aaa
 aaa
@@ -115689,14 +115821,14 @@ cpL
 crb
 csd
 dvY
-vLD
+lMJ
 krD
-krD
+jNV
+jOj
+pGw
+obJ
+hiz
 noG
-krD
-noG
-krD
-krD
 aaa
 aaa
 aaa
@@ -115947,13 +116079,13 @@ dvY
 dvY
 dvY
 aaf
-aaf
-aaf
-aaa
-aaa
-aaa
-aaa
-aaa
+krD
+krD
+sRC
+twK
+hiz
+noG
+noG
 aaa
 aaa
 aaa
@@ -116204,13 +116336,13 @@ crc
 aaf
 ctl
 aaa
-aaf
-aaf
-anT
-anT
-anT
-aaf
-aaf
+aaa
+krD
+krD
+noG
+noG
+noG
+aaa
 aaf
 lMJ
 lMJ
@@ -116462,16 +116594,16 @@ ack
 ack
 aaf
 aaf
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aaf
+aaf
+aaf
+aaf
+aaf
+aaf
+lMJ
+aaa
+aaa
+mfY
 aaf
 aaf
 anT
@@ -116718,17 +116850,17 @@ cre
 aaa
 ack
 aaa
+aaf
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+kCz
+kCz
+kCz
+uWb
+kCz
+kCz
+kCz
+lMJ
 aaf
 aaa
 aqB

--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -3283,7 +3283,6 @@
 /obj/machinery/shower{
 	pixel_y = 22
 	},
-/obj/item/soap,
 /turf/open/floor/plasteel/freezer,
 /area/mine/living_quarters)
 "DY" = (

--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -2396,6 +2396,20 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"iU" = (
+/obj/machinery/button/door{
+	id = "miningbathroom";
+	name = "Door Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_x = 0;
+	pixel_y = -25;
+	specialfunctions = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/plasteel/freezer,
+/area/mine/living_quarters)
 "iX" = (
 /obj/structure/stone_tile,
 /obj/structure/stone_tile{
@@ -2491,6 +2505,13 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"jy" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/freezer,
+/area/mine/living_quarters)
 "jF" = (
 /obj/structure/stone_tile/surrounding_tile,
 /obj/structure/stone_tile/surrounding_tile{
@@ -2637,6 +2658,12 @@
 /obj/structure/stone_tile/center,
 /turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"kK" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/freezer,
+/area/mine/living_quarters)
 "kM" = (
 /obj/structure/stone_tile/block/cracked{
 	dir = 1
@@ -3241,6 +3268,60 @@
 	},
 /turf/open/indestructible/boss,
 /area/lavaland/surface/outdoors)
+"nh" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/freezer,
+/area/mine/living_quarters)
+"ty" = (
+/obj/machinery/atmospherics/pipe/manifold4w/supply,
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
+"Cj" = (
+/obj/machinery/door/window/southright,
+/obj/machinery/shower{
+	pixel_y = 22
+	},
+/obj/item/soap,
+/turf/open/floor/plasteel/freezer,
+/area/mine/living_quarters)
+"DY" = (
+/obj/machinery/door/airlock{
+	id_tag = "miningbathroom";
+	name = "Restroom"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/freezer,
+/area/mine/living_quarters)
+"Os" = (
+/obj/machinery/door/window/southleft,
+/obj/machinery/shower{
+	pixel_y = 22
+	},
+/turf/open/floor/plasteel/freezer,
+/area/mine/living_quarters)
+"OE" = (
+/obj/machinery/door/airlock{
+	name = "Restroom"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/freezer,
+/area/mine/living_quarters)
+"TX" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12
+	},
+/obj/structure/mirror{
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel/freezer,
+/area/mine/living_quarters)
 "Uq" = (
 /obj/docking_port/stationary{
 	area_type = /area/lavaland/surface/outdoors;
@@ -3343,6 +3424,12 @@
 "WK" = (
 /obj/effect/baseturf_helper/lava_land/surface,
 /turf/closed/wall,
+/area/mine/living_quarters)
+"ZY" = (
+/obj/structure/toilet{
+	dir = 8
+	},
+/turf/open/floor/plasteel/freezer,
 /area/mine/living_quarters)
 
 (1,1,1) = {"
@@ -13349,7 +13436,7 @@ eN
 fi
 fN
 eN
-fi
+ty
 fp
 cR
 ab
@@ -13606,8 +13693,8 @@ dQ
 cM
 cM
 cM
-cR
-cR
+OE
+cM
 cM
 ai
 ab
@@ -13862,9 +13949,9 @@ fk
 fk
 fI
 cM
-ab
-ab
-ab
+Os
+nh
+cM
 ai
 ad
 ai
@@ -14119,9 +14206,9 @@ fk
 fC
 fk
 cM
-ab
-aj
-ab
+Cj
+jy
+cM
 ab
 ai
 ai
@@ -14376,9 +14463,9 @@ fu
 fD
 fJ
 cM
-ai
-aj
-aj
+cM
+DY
+cM
 aj
 aj
 aj
@@ -14633,9 +14720,9 @@ fk
 fE
 fK
 cM
-ad
-aj
-aj
+TX
+iU
+cM
 aj
 aj
 aj
@@ -14890,9 +14977,9 @@ fk
 fF
 fk
 cM
-ai
-aj
-aj
+ZY
+kK
+cM
 aj
 aj
 aj
@@ -15147,9 +15234,9 @@ fv
 fG
 fL
 cM
-ai
-ai
-aj
+cM
+cM
+cM
 aj
 aj
 aj


### PR DESCRIPTION
Original Author: 81Denton
Original PR Link: https://github.com/tgstation/tgstation/pull/39379

:cl: Denton
tweak: Metastation: Spruced up the RnD circuitry lab; no gameplay changes.
tweak: Due to exemplary performance, NanoTrasen has awarded Shaft Miners with their very own bathroom, constructed at the mining station dormitories. Construction costs will be deducted from their salaries.
/:cl:

Metastation's circuitry lab is this drab box, I basically recycled the design of the circuitry lab I did for Pubbystation way back when. 
Are the inner light purple borders maybe a little too much?

![meta-circuit](https://user-images.githubusercontent.com/32391752/43263633-224cb806-90e4-11e8-8bda-92cd9951756d.PNG)

The mining station also didn't have a bathroom:

![mining-bathroom](https://user-images.githubusercontent.com/32391752/43263645-2a46583c-90e4-11e8-9fe7-d1586332afb7.PNG)
