### PR TITLE
[PR MIRROR]: Add moth week as a holiday

### DIFF
--- a/code/modules/holiday/holidays.dm
+++ b/code/modules/holiday/holidays.dm
@@ -373,6 +373,9 @@
 	end_day = 29
 	end_month = JULY
 
+/datum/holiday/moth/getStationPrefix()
+	return pick("Mothball","Lepidopteran","Lightbulb","Moth","Giant Atlas","Twin-spotted Sphynx","Madagascan Sunset","Luna","Death's Head","Emperor Gum","Polyphenus","Oleander Hawk","Io","Rosy Maple","Cecropia","Noctuidae","Giant Leopard","Dysphania Militaris","Garden Tiger")
+
 /datum/holiday/ramadan
 	name = "Start of Ramadan"
 

--- a/code/modules/holiday/holidays.dm
+++ b/code/modules/holiday/holidays.dm
@@ -205,7 +205,7 @@
 	name = "UFO Day"
 	begin_day = 2
 	begin_month = JULY
-	drone_hat = /obj/item/clothing/mask/facehugger/dead 
+	drone_hat = /obj/item/clothing/mask/facehugger/dead
 
 /datum/holiday/UFO/getStationPrefix() //Is such a thing even possible?
 	return pick("Ayy","Truth","Tsoukalos","Mulder") //Yes it is!
@@ -365,6 +365,13 @@
 	begin_week = 3
 	begin_month = JUNE
 	begin_weekday = SUNDAY
+
+/datum/holiday/moth
+	name = "Moth Week"
+	begin_day = 21
+	begin_month = JULY
+	end_day = 29
+	end_month = JULY
 
 /datum/holiday/ramadan
 	name = "Start of Ramadan"


### PR DESCRIPTION
Original Author: Jared-Fogle
Original PR Link: https://github.com/tgstation/tgstation/pull/39377

:cl:
add: NanoTrasen now officially recognizes Moth Week as a holiday.
/:cl:

Completely untested. If you're going to merge it merge it quick since it ends in 4 days!

[why]: # http://nationalmothweek.org/

Not sure about other servers but Bagil is having fun with moth week (I think).