### PR TITLE
[PR MIRROR]: you can now make mouse traps

### DIFF
--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -370,6 +370,14 @@
 				/obj/item/stack/rods = 12)
 	category = CAT_MISC
 
+/datum/crafting_recipe/mousetrap
+	name = "Mouse Trap"
+	result = /obj/item/assembly/mousetrap
+	time = 10
+	reqs = list(/obj/item/stack/sheet/cardboard = 1,
+				/obj/item/stack/rods = 1)
+	category = CAT_MISC
+
 /datum/crafting_recipe/papersack
 	name = "Paper Sack"
 	result = /obj/item/storage/box/papersack


### PR DESCRIPTION
Original Author: Tlaltecuhtli
Original PR Link: https://github.com/tgstation/tgstation/pull/39375

:cl:
add:mouse traps are craftable
/:cl: