### PR TITLE
[PR MIRROR]: Xrays go through mobs and blob tiles again

### DIFF
--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -56,7 +56,7 @@
 	damage = 15
 	irradiate = 30
 	range = 15
-	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE | PASSCLOSEDTURF
+	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE | PASSCLOSEDTURF | PASSBLOB | PASSMOB
 
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/green_laser
 	light_color = LIGHT_COLOR_GREEN


### PR DESCRIPTION
Original Author: Kraseo
Original PR Link: https://github.com/tgstation/tgstation/pull/39361

:cl: Kraso
balance: Xray beams go through mobs and blobs.
/:cl:

[why]: X-rays used to be the tool against blobs and they aren't as widespread thanks to techwebs
