### PR TITLE
[PR MIRROR]: Increases Odysseus mech movespeed

### DIFF
--- a/code/game/mecha/medical/odysseus.dm
+++ b/code/game/mecha/medical/odysseus.dm
@@ -2,7 +2,7 @@
 	desc = "These exosuits are developed and produced by Vey-Med. (&copy; All rights reserved)."
 	name = "\improper Odysseus"
 	icon_state = "odysseus"
-	step_in = 3
+	step_in = 2
 	max_temperature = 15000
 	max_integrity = 120
 	wreckage = /obj/structure/mecha_wreckage/odysseus


### PR DESCRIPTION
Original Author: 81Denton
Original PR Link: https://github.com/tgstation/tgstation/pull/39357

:cl: Denton
balance: The Odysseus mech's movespeed has been increased.
/:cl:

Right now, the Odysseus is in an awkward spot where it is worse at transporting critical patients than a player with a stabilized light pink slime extract, a medical cyborg or even just a player with an epipen+roller bed/office chair.
This is due to its low movespeed - since it moves as fast as a Gygax, you'll get the patient to medbay quicker if you just get out and drag them.

Setting step_in to 2 will make it as fast as a Phazon, which imo won't result in balance issues if you consider that it has less max integrity than a HONK and its only weapon is completely blocked by thick clothing.