### PR TITLE
[PR MIRROR]: [WIP]Cloth golem gib fix

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -732,6 +732,19 @@
 	new /obj/structure/cloth_pile(get_turf(H), H)
 	..()
 
+mob/living/carbon/human/species/golem/cloth/gib() //Overrides gib code for cloth golems. Mummies have no organs and are dusted upon gibbing.
+
+	if(istype(loc, /obj/structure/cloth_pile)) //If the cloth golem is gibbed while inside it's cloth pile. (Likely a Megafauna gib)
+		var/turf/T = get_turf(loc)
+		to_chat(src, "<span class='userdanger'>An overwhelming force pulverizes your remains!</span>")
+		new /obj/effect/decal/cleanable/ash(T)
+		QDEL_NULL(loc)
+
+	else
+		to_chat(src, "<span class='userdanger'>An overwhelming force pulverizes you!</span>")
+		src.dust(just_ash = TRUE)
+		QDEL_NULL(src)
+
 /obj/structure/cloth_pile
 	name = "pile of bandages"
 	desc = "It emits a strange aura, as if there was still life within it..."

--- a/config/admins.txt
+++ b/config/admins.txt
@@ -139,3 +139,4 @@ The Dreamweaver = Game Master
 Naksuasdf = Game Master
 MrDoomBringer = Game Master
 shizcalev = Game Master
+Solar Marine = Game Master


### PR DESCRIPTION
Original Author: CreationPro
Original PR Link: https://github.com/tgstation/tgstation/pull/39239

[Changelogs]: # (A fix for #39050 . Overrides the cloth golems' gib() proc so that it turns them to ashes instead. If the golem is in a cloth_pile state it also deletes the pile instead of just leaving it there. (What megafauna used to do, basically))

:cl: CreationPro
tweak: Changed cloth golems' gib() function to turn them to ashes instead.
fix: fixed an issue where a cloth golem would get gibbed by megafauna, told to wait for regeneration and get it's head decapitated right after, leaving a permanently dead cloth pile behind.
/:cl:

[why]: # (Fixes #39050)
