### PR TITLE
[PR MIRROR]: Fixes few map loading race conditions.

### DIFF
--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -75,6 +75,9 @@ SUBSYSTEM_DEF(air)
 /datum/controller/subsystem/air/fire(resumed = 0)
 	var/timer = TICK_USAGE_REAL
 
+	if(map_loading)
+		pause()
+	
 	if(currentpart == SSAIR_PIPENETS || !resumed)
 		process_pipenets(resumed)
 		cost_pipenets = MC_AVERAGE(cost_pipenets, TICK_DELTA_TO_MS(TICK_USAGE_REAL - timer))

--- a/code/modules/mapping/map_template.dm
+++ b/code/modules/mapping/map_template.dm
@@ -22,33 +22,6 @@
 		height = bounds[MAP_MAXY]
 	return bounds
 
-/datum/map_template/proc/initTemplateBounds(var/list/bounds)
-	var/list/obj/machinery/atmospherics/atmos_machines = list()
-	var/list/obj/structure/cable/cables = list()
-	var/list/atom/atoms = list()
-
-	var/list/turfs = block(	locate(bounds[MAP_MINX], bounds[MAP_MINY], bounds[MAP_MINZ]),
-							locate(bounds[MAP_MAXX], bounds[MAP_MAXY], bounds[MAP_MAXZ]))
-	var/list/border = block(locate(max(bounds[MAP_MINX]-1, 1),			max(bounds[MAP_MINY]-1, 1),			 bounds[MAP_MINZ]),
-							locate(min(bounds[MAP_MAXX]+1, world.maxx),	min(bounds[MAP_MAXY]+1, world.maxy), bounds[MAP_MAXZ])) - turfs
-	for(var/L in turfs)
-		var/turf/B = L
-		atoms += B
-		for(var/A in B)
-			atoms += A
-			if(istype(A, /obj/structure/cable))
-				cables += A
-				continue
-			if(istype(A, /obj/machinery/atmospherics))
-				atmos_machines += A
-	for(var/L in border)
-		var/turf/T = L
-		T.air_update_turf(TRUE) //calculate adjacent turfs along the border to prevent runtimes
-
-	SSatoms.InitializeAtoms(atoms)
-	SSmachines.setup_template_powernets(cables)
-	SSair.setup_template_machinery(atmos_machines)
-
 /datum/map_template/proc/load_new_z()
 	var/x = round((world.maxx - width)/2)
 	var/y = round((world.maxy - height)/2)
@@ -62,7 +35,7 @@
 	repopulate_sorted_areas()
 
 	//initialize things that are normally initialized after map load
-	initTemplateBounds(bounds)
+	parsed.initTemplateBounds()
 	smooth_zlevel(world.maxz)
 	log_game("Z-level [name] loaded at at [x],[y],[world.maxz]")
 
@@ -87,7 +60,7 @@
 		repopulate_sorted_areas()
 
 	//initialize things that are normally initialized after map load
-	initTemplateBounds(bounds)
+	parsed.initTemplateBounds()
 
 	log_game("[name] loaded at at [T.x],[T.y],[T.z]")
 	return bounds

--- a/code/modules/mapping/reader.dm
+++ b/code/modules/mapping/reader.dm
@@ -26,8 +26,6 @@ GLOBAL_DATUM_INIT(_preloader, /datum/map_preloader, new)
 
 	var/list/turfs = block(	locate(bounds[MAP_MINX], bounds[MAP_MINY], bounds[MAP_MINZ]),
 							locate(bounds[MAP_MAXX], bounds[MAP_MAXY], bounds[MAP_MAXZ]))
-	var/list/border = block(locate(max(bounds[MAP_MINX]-1, 1),			max(bounds[MAP_MINY]-1, 1),			 bounds[MAP_MINZ]),
-							locate(min(bounds[MAP_MAXX]+1, world.maxx),	min(bounds[MAP_MAXY]+1, world.maxy), bounds[MAP_MAXZ])) - turfs
 	for(var/L in turfs)
 		var/turf/B = L
 		atoms += B
@@ -38,13 +36,12 @@ GLOBAL_DATUM_INIT(_preloader, /datum/map_preloader, new)
 				continue
 			if(istype(A, /obj/machinery/atmospherics))
 				atmos_machines += A
-	for(var/L in border)
-		var/turf/T = L
-		T.air_update_turf(TRUE) //calculate adjacent turfs along the border to prevent runtimes
-
+	//We're not finished with loading stuff yet.
+	Master.StartLoadingMap()
 	SSatoms.InitializeAtoms(atoms)
 	SSmachines.setup_template_powernets(cables)
 	SSair.setup_template_machinery(atmos_machines)
+	Master.StopLoadingMap()
 
 /datum/maploader
 		// /"([a-zA-Z]+)" = \(((?:.|\n)*?)\)\n(?!\t)|\((\d+),(\d+),(\d+)\) = \{"([a-zA-Z\n]*)"\}/g


### PR DESCRIPTION
Original Author: AnturK
Original PR Link: https://github.com/tgstation/tgstation/pull/39236

Short story this is pausing air subsystem during maploads. Also cleans some code duplication. This is pretty heavy handed but the alternatives would cost performance in more common air processing areas. The alternative would be to let map loaders recompute atmos adjacent turfs immediately.

Short description of first issue:

1. Two adjacent open turfs A and B

2. A is processed by mapload changing to closed turf, this adds surrounding turfs to active list including yet-to-be-loaded B. At this point atmos adjacent values are still outdated on both turfs since we defer it.

3. Maploader pauses here to let other subsystems tick, which makes air process turf B. Runtimes happen since A is closed turf.

Second issue is more or less the same but with Initialize calls in map templates, if there's enough object subsystem stagger kicks in, air fires on turfs with uninitialized neighbours, runtimes happen.

