### PR TITLE
[PR MIRROR]: Makes to_chat queue messages rather than immediately sending them

### DIFF
--- a/code/__DEFINES/subsystems.dm
+++ b/code/__DEFINES/subsystems.dm
@@ -56,17 +56,18 @@
 #define INIT_ORDER_BLACKBOX 17
 #define INIT_ORDER_SERVER_MAINT 16
 #define INIT_ORDER_INPUT 15
-#define INIT_ORDER_RESEARCH 14
-#define INIT_ORDER_EVENTS 13
-#define INIT_ORDER_JOBS 12
-#define INIT_ORDER_QUIRKS 11
-#define INIT_ORDER_TICKER 10
-#define INIT_ORDER_MAPPING 9
-#define INIT_ORDER_NETWORKS 8
-#define INIT_ORDER_ATOMS 7
-#define INIT_ORDER_LANGUAGE 6
-#define INIT_ORDER_MACHINES 5
-#define INIT_ORDER_CIRCUIT 4
+#define INIT_ORDER_CHAT 14
+#define INIT_ORDER_RESEARCH 13
+#define INIT_ORDER_EVENTS 12
+#define INIT_ORDER_JOBS 11
+#define INIT_ORDER_QUIRKS 10
+#define INIT_ORDER_TICKER 9
+#define INIT_ORDER_MAPPING 8
+#define INIT_ORDER_NETWORKS 7
+#define INIT_ORDER_ATOMS 6
+#define INIT_ORDER_LANGUAGE 5
+#define INIT_ORDER_MACHINES 4
+#define INIT_ORDER_CIRCUIT 3
 #define INIT_ORDER_TIMER 1
 #define INIT_ORDER_DEFAULT 0
 #define INIT_ORDER_AIR -1
@@ -110,7 +111,8 @@
 #define FIRE_PRIORITY_TGUI			110
 #define FIRE_PRIORITY_TICKER		200
 #define FIRE_PRIORITY_OVERLAYS		500
-#define FIRE_PRIORITY_INPUT			1000 // This must always always be the max highest priority. Player input must never be lost.
+#define FIRE_PRIORITY_CHAT			900		// Let's have this always be just under the number 1
+#define FIRE_PRIORITY_INPUT			1000	// This must always always be the max highest priority. Player input must never be lost.
 
 // SS runlevels
 

--- a/code/controllers/subsystem/chat.dm
+++ b/code/controllers/subsystem/chat.dm
@@ -1,0 +1,52 @@
+SUBSYSTEM_DEF(chat)
+	name = "Chat"
+	wait = 5
+	init_order = INIT_ORDER_CHAT
+	priority = FIRE_PRIORITY_CHAT
+	runlevels = RUNLEVELS_DEFAULT | RUNLEVEL_LOBBY
+
+	var/list/browser_chat_queue
+	var/list/old_chat_queue
+
+/datum/controller/subsystem/chat/Initialize()
+	browser_chat_queue = list()
+	old_chat_queue = list()
+	return ..()
+
+/datum/controller/subsystem/chat/fire()
+	var/list/queue = browser_chat_queue
+	while(queue.len)
+		var/client/user = queue[queue.len]
+		var/message = queue[user]
+		queue.len--
+		if(istype(message, /list))
+			user << output(list2params(message), "browseroutput:output_list")
+		else
+			user << output(message, "browseroutput:output")
+	
+	queue = old_chat_queue
+	while(queue.len)
+		var/client/user = queue[queue.len]
+		var/message = queue[user]
+		queue.len--
+		if(istype(message, /list))
+			message = jointext(message, "\n")
+		SEND_TEXT(user, message)
+
+/datum/controller/subsystem/chat/proc/queue_message(client/user, message, oldchat=FALSE)
+	if(!oldchat)
+		if(!user.chatOutput || user.chatOutput.broken) // A player who hasn't updated his skin file.
+			return
+		if(!user.chatOutput.loaded)
+			//Client still loading, put their messages in a queue
+			user.chatOutput.messageQueue += message
+			return
+		message = url_encode(message)
+	var/list/queue = oldchat ? old_chat_queue : browser_chat_queue
+	if(!queue[user])						// No entry yet; Directly set it
+		queue[user] = message
+	else if(!istype(queue[user], /list))	// Solo entry; Convert to list
+		queue[user] = list(queue[user], message)
+	else									// Multi entry in list; Append
+		queue[user] += message
+		

--- a/code/modules/goonchat/browserOutput.dm
+++ b/code/modules/goonchat/browserOutput.dm
@@ -224,16 +224,20 @@ GLOBAL_DATUM_INIT(iconCache, /savefile, new("data/iconCache.sav")) //Cache of ic
 		if (!C)
 			continue
 
-		//Send it to the old style output window.
-		SEND_TEXT(C, original_message)
+		if(SSticker.current_state != GAME_STATE_STARTUP)
+			SSchat.queue_message(C, original_message, oldchat=TRUE)
+			SSchat.queue_message(C, message)
+		else
+			//Send it to the old style output window.
+			SEND_TEXT(C, original_message)
 
-		if(!C.chatOutput || C.chatOutput.broken) // A player who hasn't updated his skin file.
-			continue
+			if(!C.chatOutput || C.chatOutput.broken) // A player who hasn't updated his skin file.
+				continue
 
-		if(!C.chatOutput.loaded)
-			//Client still loading, put their messages in a queue
-			C.chatOutput.messageQueue += message
-			continue
+			if(!C.chatOutput.loaded)
+				//Client still loading, put their messages in a queue
+				C.chatOutput.messageQueue += message
+				continue
 
-		// url_encode it TWICE, this way any UTF-8 characters are able to be decoded by the Javascript.
-		C << output(url_encode(url_encode(message)), "browseroutput:output")
+			// url_encode it TWICE, this way any UTF-8 characters are able to be decoded by the Javascript.
+			C << output(url_encode(url_encode(message)), "browseroutput:output")

--- a/code/modules/goonchat/browserassets/js/browserOutput.js
+++ b/code/modules/goonchat/browserassets/js/browserOutput.js
@@ -231,6 +231,13 @@ function iconError(E) {
 	}, opts.imageRetryDelay);
 }
 
+function output_list() {
+	for (var i = 0; i < arguments.length; i++) {
+		var message = arguments[i];
+		output(message);
+	}
+}
+
 //Send a message to the client
 function output(message, flag) {
 	if (typeof message === 'undefined') {

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -204,6 +204,7 @@
 #include "code\controllers\subsystem\atoms.dm"
 #include "code\controllers\subsystem\augury.dm"
 #include "code\controllers\subsystem\blackbox.dm"
+#include "code\controllers\subsystem\chat.dm"
 #include "code\controllers\subsystem\communications.dm"
 #include "code\controllers\subsystem\dbcore.dm"
 #include "code\controllers\subsystem\dcs.dm"


### PR DESCRIPTION
Original Author: ninjanomnom
Original PR Link: https://github.com/tgstation/tgstation/pull/39201

:cl: ninjanomnom
fix: Chat spam should no longer lag or freeze the client
/:cl:

fixes #38863

Someone more experienced with the chat browser should really take a look at this