### PR TITLE
[PR MIRROR]: Removes canvases on runtime

### DIFF
--- a/code/game/objects/structures/artstuff.dm
+++ b/code/game/objects/structures/artstuff.dm
@@ -13,7 +13,6 @@
 	max_integrity = 60
 	var/obj/item/canvas/painting = null
 
-
 //Adding canvases
 /obj/structure/easel/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/canvas))
@@ -66,6 +65,14 @@ GLOBAL_LIST_INIT(globalBlankCanvases, new(AMT_OF_CANVASES))
 	icon_state = "23x23"
 	whichGlobalBackup = 4
 
+//HEY YOU
+//ARE YOU READING THE CODE FOR CANVASES?
+//ARE YOU AWARE THEY CRASH HALF THE SERVER WHEN SOMEONE DRAWS ON THEM...
+//...AND NOBODY CAN FIGURE OUT WHY?
+//THEN GO ON BRAVE TRAVELER
+//TRY TO FIX THEM AND REMOVE THIS CODE
+/obj/item/canvas/New()
+	qdel(src)
 
 //Find the right size blank canvas
 /obj/item/canvas/proc/getGlobalBackup()

--- a/code/game/objects/structures/artstuff.dm
+++ b/code/game/objects/structures/artstuff.dm
@@ -70,11 +70,11 @@ GLOBAL_LIST_INIT(globalBlankCanvases, new(AMT_OF_CANVASES))
 //ARE YOU AWARE THEY CRASH HALF THE SERVER WHEN SOMEONE DRAWS ON THEM...
 //...AND NOBODY CAN FIGURE OUT WHY?
 //THEN GO ON BRAVE TRAVELER
-//TRY TO FIX THEM AND REMOVE THIS CODE (AND THE BLOCK COMMENT)
+//TRY TO FIX THEM AND REMOVE THIS CODE
 /obj/item/canvas/Initialize()
+	..()
 	return INITIALIZE_HINT_QDEL //Delete on creation
 
-/*
 //Find the right size blank canvas
 /obj/item/canvas/proc/getGlobalBackup()
 	. = null
@@ -132,5 +132,4 @@ GLOBAL_LIST_INIT(globalBlankCanvases, new(AMT_OF_CANVASES))
 		user.visible_message("<span class='notice'>[user] cleans the canvas.</span>","<span class='notice'>You clean the canvas.</span>")
 
 
-*/
 #undef AMT_OF_CANVASES

--- a/code/game/objects/structures/artstuff.dm
+++ b/code/game/objects/structures/artstuff.dm
@@ -70,10 +70,11 @@ GLOBAL_LIST_INIT(globalBlankCanvases, new(AMT_OF_CANVASES))
 //ARE YOU AWARE THEY CRASH HALF THE SERVER WHEN SOMEONE DRAWS ON THEM...
 //...AND NOBODY CAN FIGURE OUT WHY?
 //THEN GO ON BRAVE TRAVELER
-//TRY TO FIX THEM AND REMOVE THIS CODE
-/obj/item/canvas/New()
-	qdel(src)
+//TRY TO FIX THEM AND REMOVE THIS CODE (AND THE BLOCK COMMENT)
+/obj/item/canvas/Initialize()
+	return INITIALIZE_HINT_QDEL //Delete on creation
 
+/*
 //Find the right size blank canvas
 /obj/item/canvas/proc/getGlobalBackup()
 	. = null
@@ -131,5 +132,5 @@ GLOBAL_LIST_INIT(globalBlankCanvases, new(AMT_OF_CANVASES))
 		user.visible_message("<span class='notice'>[user] cleans the canvas.</span>","<span class='notice'>You clean the canvas.</span>")
 
 
-
+*/
 #undef AMT_OF_CANVASES


### PR DESCRIPTION
Original Author: Jared-Fogle
Original PR Link: https://github.com/tgstation/tgstation/pull/39401

[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl:
del: Temporarily removes canvases until someone figures out how to fix them.
/:cl:

[why]: # #38942 I didn't make it a config option because if you're going to be fixing the canvases you'd be removing the code for the config option anyway.