### PR TITLE
[PR MIRROR]: Removes slippery component from turf/open/water

### DIFF
--- a/code/__DEFINES/admin.dm
+++ b/code/__DEFINES/admin.dm
@@ -38,7 +38,7 @@
 
 #define R_DEFAULT R_AUTOLOGIN
 
-#define R_MAXPERMISSION 4096 //This holds the maximum value for a permission. It is used in iteration, so keep it updated.
+#define R_EVERYTHING (1<<15)-1 //the sum of all other rank permissions, used for +EVERYTHING
 
 #define ADMIN_QUE(user) "(<a href='?_src_=holder;[HrefToken(TRUE)];adminmoreinfo=[REF(user)]'>?</a>)"
 #define ADMIN_FLW(user) "(<a href='?_src_=holder;[HrefToken(TRUE)];adminplayerobservefollow=[REF(user)]'>FLW</a>)"

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -543,3 +543,28 @@
 		file_data["admins"]["[i]"] = A.rank.name
 	fdel(json_file)
 	WRITE_FILE(json_file, json_encode(file_data))
+
+/datum/controller/subsystem/ticker/proc/update_everything_flag_in_db()
+	for(var/datum/admin_rank/R in GLOB.admin_ranks)
+		var/list/flags = list()
+		if(R.include_rights == R_EVERYTHING)
+			flags += "flags"
+		if(R.exclude_rights == R_EVERYTHING)
+			flags += "exclude_flags"
+		if(R.can_edit_rights == R_EVERYTHING)
+			flags += "can_edit_flags"
+		if(!flags.len)
+			continue
+		var/flags_to_check = flags.Join(" != [R_EVERYTHING] AND ") + " != [R_EVERYTHING]"
+		var/datum/DBQuery/query_check_everything_ranks = SSdbcore.NewQuery("SELECT flags, exclude_flags, can_edit_flags FROM [format_table_name("admin_ranks")] WHERE rank = '[R.name]' AND ([flags_to_check])")
+		if(!query_check_everything_ranks.Execute())
+			qdel(query_check_everything_ranks)
+			return
+		if(query_check_everything_ranks.NextRow()) //no row is returned if the rank already has the correct flag value
+			var/flags_to_update = flags.Join(" = [R_EVERYTHING], ") + " = [R_EVERYTHING]"
+			var/datum/DBQuery/query_update_everything_ranks = SSdbcore.NewQuery("UPDATE [format_table_name("admin_ranks")] SET [flags_to_update] WHERE rank = '[R.name]'")
+			if(!query_update_everything_ranks.Execute())
+				qdel(query_update_everything_ranks)
+				return
+			qdel(query_update_everything_ranks)
+		qdel(query_check_everything_ranks)

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -626,6 +626,7 @@ SUBSYSTEM_DEF(ticker)
 /datum/controller/subsystem/ticker/Shutdown()
 	gather_newscaster() //called here so we ensure the log is created even upon admin reboot
 	save_admin_data()
+	update_everything_flag_in_db()
 	if(!round_end_sound)
 		round_end_sound = pick(\
 		'sound/roundend/newroundsexy.ogg',

--- a/code/game/turfs/simulated/water.dm
+++ b/code/game/turfs/simulated/water.dm
@@ -11,6 +11,3 @@
 	bullet_sizzle = TRUE
 	bullet_bounce_sound = null //needs a splashing sound one day.
 
-/turf/open/water/Initialize()
-	. = ..()
-	MakeSlippery(TURF_WET_WATER, INFINITY, 0, INFINITY, TRUE)

--- a/code/modules/admin/admin_ranks.dm
+++ b/code/modules/admin/admin_ranks.dm
@@ -71,7 +71,7 @@ GLOBAL_PROTECT(protected_ranks)
 		if("varedit")
 			flag = R_VAREDIT
 		if("everything","host","all")
-			flag = ALL
+			flag = R_EVERYTHING
 		if("sound","sounds")
 			flag = R_SOUNDS
 		if("spawn","create")
@@ -182,9 +182,12 @@ GLOBAL_PROTECT(protected_ranks)
 			return FALSE
 		var/list/json = json_decode(backup_file)
 		for(var/J in json["ranks"])
+			var/skip
 			for(var/datum/admin_rank/R in GLOB.admin_ranks)
 				if(R.name == "[J]") //this rank was already loaded from txt override
-					continue
+					skip = TRUE
+			if(skip)
+				continue
 			var/datum/admin_rank/R = new("[J]", json["ranks"]["[J]"]["include rights"], json["ranks"]["[J]"]["exclude rights"], json["ranks"]["[J]"]["can edit rights"])
 			if(!R)
 				continue
@@ -266,9 +269,12 @@ GLOBAL_PROTECT(protected_ranks)
 				return
 			backup_file_json = json_decode(backup_file)
 		for(var/J in backup_file_json["admins"])
+			var/skip
 			for(var/A in GLOB.admin_datums + GLOB.deadmins)
 				if(A == "[J]") //this admin was already loaded from txt override
-					continue
+					skip = TRUE
+			if(skip)
+				continue
 			new /datum/admins(rank_names[ckeyEx(backup_file_json["admins"]["[J]"])], ckey("[J]"))
 	#ifdef TESTING
 	var/msg = "Admins Built:\n"

--- a/code/modules/admin/holder2.dm
+++ b/code/modules/admin/holder2.dm
@@ -137,7 +137,7 @@ GLOBAL_PROTECT(href_token)
 /datum/admins/proc/check_if_greater_rights_than_holder(datum/admins/other)
 	if(!other)
 		return 1 //they have no rights
-	if(rank.rights == 65535)
+	if(rank.rights == R_EVERYTHING)
 		return 1 //we have all the rights
 	if(src == other)
 		return 1 //you always have more rights than yourself

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -188,7 +188,7 @@ GLOBAL_LIST_EMPTY(external_rsc_urls)
 	if(CONFIG_GET(flag/enable_localhost_rank) && !connecting_admin)
 		var/localhost_addresses = list("127.0.0.1", "::1")
 		if(isnull(address) || (address in localhost_addresses))
-			var/datum/admin_rank/localhost_rank = new("!localhost!", 65535, 16384, 65535) //+EVERYTHING -DBRANKS *EVERYTHING
+			var/datum/admin_rank/localhost_rank = new("!localhost!", R_EVERYTHING, R_DBRANKS, R_EVERYTHING) //+EVERYTHING -DBRANKS *EVERYTHING
 			new /datum/admins(localhost_rank, ckey, 1, 1)
 	//preferences datum - also holds some persistent data for the client (because we may as well keep these datums to a minimum)
 	prefs = GLOB.preferences_datums[ckey]

--- a/html/changelogs/AutoChangeLog-pr-39355.yml
+++ b/html/changelogs/AutoChangeLog-pr-39355.yml
@@ -1,0 +1,4 @@
+author: "ShizCalev"
+delete-after: True
+changes: 
+  - bugfix: "Destroying a camera will now clear it's alarm."

--- a/html/changelogs/AutoChangeLog-pr-39390.yml
+++ b/html/changelogs/AutoChangeLog-pr-39390.yml
@@ -1,0 +1,4 @@
+author: "ninjanomnom"
+delete-after: True
+changes: 
+  - bugfix: "The cargo shuttle should move normally again"


### PR DESCRIPTION
Original Author: CitrusGender
Original PR Link: https://github.com/tgstation/tgstation/pull/39397

:cl: 
del: Removed slippery component from water turf
/:cl:

![image](https://user-images.githubusercontent.com/31262308/43306657-e236b47c-9149-11e8-8abb-7d1cc9d80de0.png)

[why]: # yeah this is a little bit of a problem when trying to make things look good. Obviously, this could use a complete rework to make it like waist high or whatever but I don't have enough time since the charity event is next week. 

The event will be using water a lot so this is a problem.