### PR TITLE
[PR MIRROR]: Add moth week as a holiday

### DIFF
--- a/code/modules/holiday/holidays.dm
+++ b/code/modules/holiday/holidays.dm
@@ -368,10 +368,9 @@
 
 /datum/holiday/moth
 	name = "Moth Week"
-	begin_day = 21
-	begin_month = JULY
-	end_day = 29
-	end_month = JULY
+
+/datum/holiday/moth/shouldCelebrate(dd, mm, yy, ww, ddd) //National Moth Week falls on the last full week of July
+	return mm == JULY && (ww == 4 || (ww == 5 && ddd == SUNDAY))
 
 /datum/holiday/moth/getStationPrefix()
 	return pick("Mothball","Lepidopteran","Lightbulb","Moth","Giant Atlas","Twin-spotted Sphynx","Madagascan Sunset","Luna","Death's Head","Emperor Gum","Polyphenus","Oleander Hawk","Io","Rosy Maple","Cecropia","Noctuidae","Giant Leopard","Dysphania Militaris","Garden Tiger")


### PR DESCRIPTION
Original Author: Jared-Fogle
Original PR Link: https://github.com/tgstation/tgstation/pull/39377

:cl:
add: NanoTrasen now officially recognizes Moth Week as a holiday.
/:cl:

Completely untested. If you're going to merge it merge it quick since it ends in 4 days!

[why]: # http://nationalmothweek.org/

Not sure about other servers but Bagil is having fun with moth week (I think).