### PR TITLE
[PR MIRROR]: Adds more bounties and rebalances them

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -58123,14 +58123,12 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cud" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/machinery/disposal/bin,
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whitepurple/side{
+	dir = 8
+	},
 /area/science/circuit)
 "cue" = (
 /obj/structure/cable{
@@ -59088,11 +59086,11 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cwd" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/white,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/whitepurple/corner{
+	dir = 4
+	},
 /area/science/circuit)
 "cwe" = (
 /obj/structure/cable,
@@ -59934,6 +59932,9 @@
 /area/science/circuit)
 "cxP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -74377,13 +74378,6 @@
 	},
 /turf/open/floor/plating,
 /area/chapel/main)
-"dka" = (
-/obj/structure/noticeboard{
-	dir = 1;
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel/white,
-/area/science/circuit)
 "dlI" = (
 /turf/closed/wall/r_wall,
 /area/engine/supermatter)
@@ -75666,7 +75660,9 @@
 /area/maintenance/starboard/fore)
 "dGH" = (
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whitepurple/side{
+	dir = 10
+	},
 /area/science/circuit)
 "dIs" = (
 /obj/machinery/door/airlock/external{
@@ -75722,16 +75718,19 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "eqq" = (
-/obj/item/screwdriver,
-/obj/structure/table/reinforced,
-/obj/structure/sign/poster/official/random{
-	pixel_y = 32
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-10"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/machinery/requests_console{
+	department = "Science";
+	departmentType = 2;
+	dir = 2;
+	name = "Science Requests Console";
+	pixel_y = 30;
+	receive_ore_updates = 1
 	},
-/obj/item/stack/sheet/metal/ten,
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/caution/stand_clear/white,
+/turf/open/floor/plasteel/purple/side,
 /area/science/circuit)
 "eqG" = (
 /obj/effect/turf_decal/stripes/line{
@@ -75743,13 +75742,9 @@
 /obj/machinery/vr_sleeper,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
-"evy" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/space)
 "eEe" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
@@ -75789,7 +75784,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/purple/corner{
+	dir = 4
+	},
 /area/science/circuit)
 "fFM" = (
 /obj/structure/cable/yellow{
@@ -75799,9 +75796,9 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 10
+	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/purple/corner,
 /area/science/circuit)
 "fHj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -75819,7 +75816,12 @@
 /obj/item/radio/intercom{
 	pixel_y = -30
 	},
-/turf/open/floor/plasteel/white,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/purple/side{
+	dir = 1
+	},
 /area/science/circuit)
 "gqA" = (
 /obj/machinery/button/door{
@@ -75860,6 +75862,7 @@
 /obj/structure/chair/office/light{
 	dir = 1
 	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "gHh" = (
@@ -75884,12 +75887,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"gRS" = (
-/obj/structure/table/reinforced,
-/obj/item/integrated_electronics/analyzer,
-/obj/item/integrated_circuit_printer,
-/turf/open/floor/plasteel/white,
-/area/science/circuit)
 "gXY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -75901,6 +75898,11 @@
 	dir = 8
 	},
 /area/engine/storage_shared)
+"hdU" = (
+/turf/open/floor/plasteel/purple/side{
+	dir = 1
+	},
+/area/science/circuit)
 "hfn" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -75941,6 +75943,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
+"imj" = (
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plasteel/whitepurple/side,
+/area/science/circuit)
 "ioI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -76001,12 +76007,12 @@
 /area/crew_quarters/fitness/recreation)
 "jyv" = (
 /obj/structure/table/reinforced,
-/obj/item/stock_parts/cell/high,
-/obj/item/stock_parts/cell/high,
-/obj/machinery/computer/security/telescreen/circuitry{
-	pixel_x = 30
+/obj/structure/sign/poster/random{
+	pixel_y = 32
 	},
-/turf/open/floor/plasteel/white,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/multitool,
+/turf/open/floor/plasteel/purple/side,
 /area/science/circuit)
 "jyQ" = (
 /obj/structure/cable{
@@ -76037,17 +76043,45 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
-/turf/open/floor/plasteel/white,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/plasteel/purple/corner{
+	dir = 8
+	},
+/area/science/circuit)
+"jNV" = (
+/obj/structure/table/reinforced,
+/obj/item/stock_parts/cell/high,
+/obj/item/stock_parts/cell/high,
+/obj/machinery/computer/security/telescreen/circuitry{
+	pixel_y = 30
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/purple/corner{
+	dir = 8
+	},
+/area/science/circuit)
+"jOj" = (
+/obj/item/integrated_electronics/analyzer,
+/obj/item/integrated_electronics/debugger,
+/obj/item/integrated_electronics/wirer,
+/obj/structure/table/reinforced,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/purple/side{
+	dir = 8
+	},
 /area/science/circuit)
 "kfu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "krD" = (
@@ -76062,9 +76096,13 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "kxk" = (
-/obj/structure/table/reinforced,
-/obj/machinery/cell_charger,
-/turf/open/floor/plasteel/white,
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/auto_name/west{
+	pixel_x = -25
+	},
+/turf/open/floor/plasteel/stairs/left,
 /area/science/circuit)
 "kys" = (
 /obj/structure/cable/yellow{
@@ -76096,6 +76134,11 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
+"kCz" = (
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/open/space/basic,
+/area/space/nearstation)
 "kDM" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -76112,10 +76155,10 @@
 /obj/item/multitool,
 /obj/item/screwdriver,
 /obj/structure/table/reinforced,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/machinery/computer/security/telescreen/circuitry{
+	pixel_y = 30
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/purple/side,
 /area/science/circuit)
 "kVo" = (
 /obj/structure/cable/yellow{
@@ -76129,6 +76172,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/structure/sign/poster/random{
+	pixel_x = -32
+	},
 /turf/open/floor/plasteel,
 /area/science/circuit)
 "llb" = (
@@ -76137,25 +76183,20 @@
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "lsv" = (
-/obj/machinery/power/apc{
-	areastring = "/area/science/circuit";
-	dir = 1;
-	name = "Circuitry Lab APC";
-	pixel_y = 30
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
 /obj/structure/table/reinforced,
-/obj/item/multitool,
-/turf/open/floor/plasteel/white,
+/obj/item/stack/sheet/metal/ten,
+/obj/item/screwdriver,
+/turf/open/floor/plasteel/purple/side,
 /area/science/circuit)
 "lzk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/white,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/whitepurple/side{
+	dir = 4
+	},
 /area/science/circuit)
 "lGS" = (
 /obj/docking_port/stationary/public_mining_dock,
@@ -76178,6 +76219,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"lQw" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/plasteel/white,
+/area/science/circuit)
 "lWY" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Telecomms Server Room"
@@ -76198,6 +76243,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"mps" = (
+/obj/structure/lattice,
+/obj/structure/grille/broken,
+/turf/open/space/basic,
+/area/space/nearstation)
 "msD" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -76216,7 +76266,12 @@
 	dir = 1;
 	pixel_y = -24
 	},
-/turf/open/floor/plasteel/white,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/purple/side{
+	dir = 1
+	},
 /area/science/circuit)
 "mzU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -76224,6 +76279,16 @@
 	},
 /turf/open/floor/plasteel/caution/corner,
 /area/engine/storage_shared)
+"mTj" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/purple/side{
+	dir = 1
+	},
+/area/science/circuit)
 "mWg" = (
 /obj/structure/girder,
 /obj/structure/grille,
@@ -76238,19 +76303,6 @@
 	},
 /turf/open/floor/plating,
 /area/engine/break_room)
-"nnK" = (
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/structure/table/reinforced,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 32
-	},
-/turf/open/floor/plasteel/white,
-/area/science/circuit)
 "noG" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -76304,6 +76356,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/circuit)
+"obJ" = (
+/turf/open/floor/plasteel/purple/corner{
+	icon_state = "purplecorner";
+	dir = 1
+	},
+/area/science/circuit)
 "obX" = (
 /obj/docking_port/stationary{
 	area_type = /area/construction/mining/aux_base;
@@ -76323,21 +76381,15 @@
 	dir = 1
 	},
 /obj/structure/table/reinforced,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/item/stock_parts/cell/high,
 /obj/item/stock_parts/cell/high,
-/obj/machinery/computer/security/telescreen/circuitry{
-	pixel_y = 30
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/purple/side,
 /area/science/circuit)
 "ohj" = (
-/obj/item/integrated_electronics/analyzer,
-/obj/item/integrated_electronics/debugger,
-/obj/item/integrated_electronics/wirer,
-/obj/structure/table/reinforced,
+/obj/structure/chair/office/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "oub" = (
@@ -76364,19 +76416,11 @@
 /area/engine/storage_shared)
 "oLW" = (
 /obj/structure/table/reinforced,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/requests_console{
-	department = "Science";
-	departmentType = 2;
-	dir = 2;
-	name = "Science Requests Console";
-	pixel_y = 30;
-	receive_ore_updates = 1
-	},
 /obj/item/integrated_electronics/debugger,
-/turf/open/floor/plasteel/white,
+/obj/structure/sign/poster/random{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/purple/side,
 /area/science/circuit)
 "oRL" = (
 /obj/docking_port/stationary{
@@ -76396,6 +76440,9 @@
 	},
 /obj/item/paper_bin,
 /obj/item/pen,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "oZg" = (
@@ -76447,6 +76494,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"pGw" = (
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/purple/side{
+	dir = 8
+	},
+/area/science/circuit)
 "pMX" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -76489,12 +76544,29 @@
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel,
 /area/engine/storage_shared)
+"qgv" = (
+/obj/machinery/light,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/turf/open/floor/plasteel/purple/side{
+	dir = 1
+	},
+/area/science/circuit)
 "qhe" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"qle" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/whitepurple/side,
+/area/science/circuit)
 "qqg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
@@ -76528,7 +76600,16 @@
 	dir = 1;
 	network = list("ss13","rd")
 	},
-/turf/open/floor/plasteel/white,
+/obj/structure/noticeboard{
+	dir = 1;
+	pixel_y = -32
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/purple/side{
+	dir = 1
+	},
 /area/science/circuit)
 "qVR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -76629,7 +76710,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
-/area/science/circuit)
+/area/maintenance/starboard/aft)
 "sGh" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -76655,6 +76736,14 @@
 "sJW" = (
 /turf/closed/wall/mineral/plastitanium,
 /area/engine/break_room)
+"tih" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/stairs/right,
+/area/science/circuit)
 "tsx" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -76664,12 +76753,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"txj" = (
-/obj/structure/chair/office/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/circuit)
 "tDM" = (
 /obj/machinery/door/airlock/engineering/glass/critical{
 	heat_proof = 1;
@@ -76687,6 +76770,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
+"tSU" = (
+/turf/open/floor/plasteel/whitepurple/side{
+	dir = 8
+	},
+/area/science/circuit)
 "tVY" = (
 /obj/structure/closet/crate,
 /obj/item/target/alien,
@@ -76768,18 +76856,24 @@
 /area/science/research)
 "uTS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+	dir = 9
 	},
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-10"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"uWb" = (
+/obj/structure/grille/broken,
+/turf/open/space/basic,
+/area/space/nearstation)
 "uYk" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/purple/side{
+	dir = 1
+	},
 /area/science/circuit)
 "vgd" = (
 /obj/item/taperecorder,
@@ -76820,6 +76914,9 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space)
+"vXM" = (
+/turf/open/floor/plasteel/whitepurple/side,
+/area/science/circuit)
 "wgw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
@@ -76872,6 +76969,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "wPB" = (
@@ -76891,6 +76991,10 @@
 "xkG" = (
 /obj/item/integrated_electronics/wirer,
 /obj/structure/table/reinforced,
+/obj/item/integrated_electronics/analyzer{
+	pixel_x = -4;
+	pixel_y = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "xse" = (
@@ -76948,7 +77052,12 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = -32
 	},
-/turf/open/floor/plasteel/white,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/purple/side{
+	dir = 1
+	},
 /area/science/circuit)
 "ybn" = (
 /obj/structure/chair/comfy/brown,
@@ -76975,8 +77084,14 @@
 /turf/open/floor/plasteel,
 /area/science/circuit)
 "ykE" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/white,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/cell_charger,
+/turf/open/floor/plasteel/purple/side{
+	dir = 1
+	},
 /area/science/circuit)
 
 (1,1,1) = {"
@@ -113382,7 +113497,7 @@ upN
 cxN
 cxN
 qJZ
-cxO
+uYk
 krD
 czG
 cAN
@@ -113635,9 +113750,9 @@ cuZ
 fFM
 cud
 kxk
-cxO
-cxO
-cxO
+tSU
+tSU
+tSU
 dGH
 mzh
 krD
@@ -113891,11 +114006,11 @@ cqY
 cuZ
 jLY
 lzk
-lzk
+tih
 cwd
 kfu
 cxP
-cxO
+vXM
 gnZ
 krD
 czI
@@ -114150,9 +114265,9 @@ cuZ
 obb
 krD
 kOt
-gRS
+llb
 oUA
-cxO
+vXM
 qRM
 krD
 aaf
@@ -114409,9 +114524,9 @@ krD
 oLW
 gGT
 wPk
-dGH
-dka
-krD
+vXM
+uYk
+noG
 aaf
 aaa
 aaf
@@ -114665,10 +114780,10 @@ lMz
 krD
 ocT
 xkG
-uTS
-cxO
+wPk
+vXM
 ykE
-krD
+noG
 aaa
 aaa
 aaa
@@ -114921,10 +115036,10 @@ dvY
 mjJ
 krD
 eqq
-llb
+lQw
 uTS
-cxO
-cxO
+vXM
+qgv
 krD
 aaa
 aaa
@@ -115175,13 +115290,13 @@ ciL
 cgs
 csc
 dvY
-evy
+dxk
 krD
 lsv
-txj
+llb
 eEe
-cxO
-cxO
+qle
+mTj
 krD
 aaa
 aaa
@@ -115432,14 +115547,14 @@ cpK
 ciL
 csc
 dvY
-vLD
+lMJ
 krD
 jyv
 ohj
-nnK
 cxO
-cxO
-krD
+imj
+hdU
+noG
 aaa
 aaa
 aaa
@@ -115689,14 +115804,14 @@ cpL
 crb
 csd
 dvY
-vLD
+lMJ
 krD
-krD
+jNV
+jOj
+pGw
+obJ
 noG
-krD
 noG
-krD
-krD
 aaa
 aaa
 aaa
@@ -115947,12 +116062,12 @@ dvY
 dvY
 dvY
 aaf
-aaf
-aaf
-aaa
-aaa
-aaa
-aaa
+krD
+krD
+krD
+krD
+noG
+noG
 aaa
 aaa
 aaa
@@ -116203,14 +116318,14 @@ cpM
 crc
 aaf
 ctl
+lMJ
+lMJ
+lMJ
+lMJ
+lMJ
+lMJ
+lMJ
 aaa
-aaf
-aaf
-anT
-anT
-anT
-aaf
-aaf
 aaf
 lMJ
 lMJ
@@ -116461,16 +116576,16 @@ crd
 ack
 ack
 aaf
+aav
+aav
 aaf
+anT
+anT
+anT
+aaf
+lMJ
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+lMJ
 aaf
 aaf
 aaf
@@ -116718,17 +116833,17 @@ cre
 aaa
 ack
 aaa
+aav
 aaa
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+uWb
+kCz
+mps
+kCz
+kCz
 aaf
 aaa
 aqB

--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -2396,6 +2396,20 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"iU" = (
+/obj/machinery/button/door{
+	id = "miningbathroom";
+	name = "Door Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_x = 0;
+	pixel_y = -25;
+	specialfunctions = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/plasteel/freezer,
+/area/mine/living_quarters)
 "iX" = (
 /obj/structure/stone_tile,
 /obj/structure/stone_tile{
@@ -2491,6 +2505,13 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"jy" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/freezer,
+/area/mine/living_quarters)
 "jF" = (
 /obj/structure/stone_tile/surrounding_tile,
 /obj/structure/stone_tile/surrounding_tile{
@@ -2637,6 +2658,12 @@
 /obj/structure/stone_tile/center,
 /turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"kK" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/freezer,
+/area/mine/living_quarters)
 "kM" = (
 /obj/structure/stone_tile/block/cracked{
 	dir = 1
@@ -3241,6 +3268,59 @@
 	},
 /turf/open/indestructible/boss,
 /area/lavaland/surface/outdoors)
+"nh" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/freezer,
+/area/mine/living_quarters)
+"ty" = (
+/obj/machinery/atmospherics/pipe/manifold4w/supply,
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
+"Cj" = (
+/obj/machinery/door/window/southright,
+/obj/machinery/shower{
+	pixel_y = 22
+	},
+/turf/open/floor/plasteel/freezer,
+/area/mine/living_quarters)
+"DY" = (
+/obj/machinery/door/airlock{
+	id_tag = "miningbathroom";
+	name = "Restroom"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/freezer,
+/area/mine/living_quarters)
+"Os" = (
+/obj/machinery/door/window/southleft,
+/obj/machinery/shower{
+	pixel_y = 22
+	},
+/turf/open/floor/plasteel/freezer,
+/area/mine/living_quarters)
+"OE" = (
+/obj/machinery/door/airlock{
+	name = "Restroom"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/freezer,
+/area/mine/living_quarters)
+"TX" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12
+	},
+/obj/structure/mirror{
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel/freezer,
+/area/mine/living_quarters)
 "Uq" = (
 /obj/docking_port/stationary{
 	area_type = /area/lavaland/surface/outdoors;
@@ -3343,6 +3423,12 @@
 "WK" = (
 /obj/effect/baseturf_helper/lava_land/surface,
 /turf/closed/wall,
+/area/mine/living_quarters)
+"ZY" = (
+/obj/structure/toilet{
+	dir = 8
+	},
+/turf/open/floor/plasteel/freezer,
 /area/mine/living_quarters)
 
 (1,1,1) = {"
@@ -13349,7 +13435,7 @@ eN
 fi
 fN
 eN
-fi
+ty
 fp
 cR
 ab
@@ -13606,8 +13692,8 @@ dQ
 cM
 cM
 cM
-cR
-cR
+OE
+cM
 cM
 ai
 ab
@@ -13862,9 +13948,9 @@ fk
 fk
 fI
 cM
-ab
-ab
-ab
+Os
+nh
+cM
 ai
 ad
 ai
@@ -14119,9 +14205,9 @@ fk
 fC
 fk
 cM
-ab
-aj
-ab
+Cj
+jy
+cM
 ab
 ai
 ai
@@ -14376,9 +14462,9 @@ fu
 fD
 fJ
 cM
-ai
-aj
-aj
+cM
+DY
+cM
 aj
 aj
 aj
@@ -14633,9 +14719,9 @@ fk
 fE
 fK
 cM
-ad
-aj
-aj
+TX
+iU
+cM
 aj
 aj
 aj
@@ -14890,9 +14976,9 @@ fk
 fF
 fk
 cM
-ai
-aj
-aj
+ZY
+kK
+cM
 aj
 aj
 aj
@@ -15147,9 +15233,9 @@ fv
 fG
 fL
 cM
-ai
-ai
-aj
+cM
+cM
+cM
 aj
 aj
 aj

--- a/code/modules/cargo/bounties/assistant.dm
+++ b/code/modules/cargo/bounties/assistant.dm
@@ -159,7 +159,6 @@
 	description = "Commander Jackson is looking for yet another fine addition to her exotic weapons collection. She will reward you handsomely for a Cat o' Nine Tails."
 	reward = 4000
 	wanted_types = list(/obj/item/melee/chainofcommand/tailwhip/kitty)
-	exclude_types = list(/obj/item/melee/chainofcommand/tailwhip)
 
 /datum/bounty/item/assistant/shard
 	name = "Shards"

--- a/code/modules/cargo/bounties/assistant.dm
+++ b/code/modules/cargo/bounties/assistant.dm
@@ -141,24 +141,17 @@
 	reward = 3000
 	wanted_types = list(/obj/item/organ/tail/lizard)
 
-/datum/bounty/item/assistant/lizard_tail_whip
-	name = "Liz o' Nine Tails"
-	description = "Commander Jackson is looking for a rather unusual addition to her exotic weapons collection. She will reward you handsomely for a Liz o' Nine Tails."
-	reward = 4000
-	wanted_types = list(/obj/item/melee/chainofcommand/tailwhip)
-	exclude_types = list(/obj/item/melee/chainofcommand/tailwhip/kitty)
-
 /datum/bounty/item/assistant/cat_tail
 	name = "Cat Tail"
 	description = "Central Command has run out of heavy duty pipe cleaners. Can you ship over a cat tail to help us out?"
 	reward = 3000
 	wanted_types = list(/obj/item/organ/tail/cat)
 
-/datum/bounty/item/assistant/cat_tail_whip
-	name = "Cat o' Nine Tails"
-	description = "Commander Jackson is looking for yet another fine addition to her exotic weapons collection. She will reward you handsomely for a Cat o' Nine Tails."
+/datum/bounty/item/assistant/tail_whip
+	name = "Nine Tails whip"
+	description = "Commander Jackson is looking for a fine addition to her exotic weapons collection. She will reward you handsomely for either a Cat or Liz o' Nine Tails."
 	reward = 4000
-	wanted_types = list(/obj/item/melee/chainofcommand/tailwhip/kitty)
+	wanted_types = list(/obj/item/melee/chainofcommand/tailwhip)
 
 /datum/bounty/item/assistant/shard
 	name = "Shards"

--- a/code/modules/cargo/bounties/assistant.dm
+++ b/code/modules/cargo/bounties/assistant.dm
@@ -141,6 +141,26 @@
 	reward = 3000
 	wanted_types = list(/obj/item/organ/tail/lizard)
 
+/datum/bounty/item/assistant/lizard_tail_whip
+	name = "Liz o' Nine Tails"
+	description = "Commander Jackson is looking for a rather unusual addition to her exotic weapons collection. She will reward you handsomely for a Liz o' Nine Tails."
+	reward = 4000
+	wanted_types = list(/obj/item/melee/chainofcommand/tailwhip)
+	exclude_types = list(/obj/item/melee/chainofcommand/tailwhip/kitty)
+
+/datum/bounty/item/assistant/cat_tail
+	name = "Cat Tail"
+	description = "Central Command has run out of heavy duty pipe cleaners. Can you ship over a cat tail to help us out?"
+	reward = 3000
+	wanted_types = list(/obj/item/organ/tail/cat)
+
+/datum/bounty/item/assistant/cat_tail_whip
+	name = "Cat o' Nine Tails"
+	description = "Commander Jackson is looking for yet another fine addition to her exotic weapons collection. She will reward you handsomely for a Cat o' Nine Tails."
+	reward = 4000
+	wanted_types = list(/obj/item/melee/chainofcommand/tailwhip/kitty)
+	exclude_types = list(/obj/item/melee/chainofcommand/tailwhip)
+
 /datum/bounty/item/assistant/shard
 	name = "Shards"
 	description = "A killer clown has been stalking CentCom, and staff have been unable to catch her because she's not wearing shoes. Please ship some shards so that a booby trap can be constructed."
@@ -150,7 +170,7 @@
 
 /datum/bounty/item/assistant/comfy_chair
 	name = "Comfy Chairs"
-	description = "Commander Pat is unhappy with his chair. He claims it hurts his back. Ship some alternatives out to humor him. "
+	description = "Commander Pat is unhappy with his chair. He claims it hurts his back. Ship some alternatives out to humor him."
 	reward = 1500
 	required_count = 5
 	wanted_types = list(/obj/structure/chair/comfy)
@@ -158,14 +178,14 @@
 /datum/bounty/item/assistant/revolver
 	name = "Revolver"
 	description = "Captain Johann of station 12 has challenged Captain Vic of station 11 to a duel. He's asked for help securing an appropriate revolver to use."
-	reward = 2000
+	reward = 4000
 	wanted_types = list(/obj/item/gun/ballistic/revolver)
 	exclude_types = list(/obj/item/gun/ballistic/revolver/doublebarrel, /obj/item/gun/ballistic/revolver/grenadelauncher)
 
 /datum/bounty/item/assistant/hand_tele
 	name = "Hand Tele"
 	description = "Central Command has come up with a genius idea: Why not teleport cargo rather than ship it? Send over a hand tele, receive payment, then wait 6-8 years while they deliberate."
-	reward = 2000
+	reward = 5000
 	wanted_types = list(/obj/item/hand_tele)
 
 /datum/bounty/item/assistant/geranium

--- a/code/modules/cargo/bounties/assistant.dm
+++ b/code/modules/cargo/bounties/assistant.dm
@@ -178,14 +178,14 @@
 /datum/bounty/item/assistant/revolver
 	name = "Revolver"
 	description = "Captain Johann of station 12 has challenged Captain Vic of station 11 to a duel. He's asked for help securing an appropriate revolver to use."
-	reward = 4000
+	reward = 2000
 	wanted_types = list(/obj/item/gun/ballistic/revolver)
 	exclude_types = list(/obj/item/gun/ballistic/revolver/doublebarrel, /obj/item/gun/ballistic/revolver/grenadelauncher)
 
 /datum/bounty/item/assistant/hand_tele
 	name = "Hand Tele"
 	description = "Central Command has come up with a genius idea: Why not teleport cargo rather than ship it? Send over a hand tele, receive payment, then wait 6-8 years while they deliberate."
-	reward = 5000
+	reward = 2000
 	wanted_types = list(/obj/item/hand_tele)
 
 /datum/bounty/item/assistant/geranium

--- a/code/modules/cargo/bounties/mech.dm
+++ b/code/modules/cargo/bounties/mech.dm
@@ -17,12 +17,12 @@
 	name = "APLU \"Ripley\""
 	reward = 13000
 	wanted_types = list(/obj/mecha/working/ripley)
+	exclude_types = list(/obj/mecha/working/ripley/firefighter)
 
 /datum/bounty/item/mech/firefighter
 	name = "APLU \"Firefighter\""
 	reward = 18000
 	wanted_types = list(/obj/mecha/working/ripley/firefighter)
-	exclude_types = list(/obj/mecha/working/ripley)
 
 /datum/bounty/item/mech/odysseus
 	name = "Odysseus"

--- a/code/modules/cargo/bounties/mech.dm
+++ b/code/modules/cargo/bounties/mech.dm
@@ -17,7 +17,6 @@
 	name = "APLU \"Ripley\""
 	reward = 13000
 	wanted_types = list(/obj/mecha/working/ripley)
-	exclude_types = list(/obj/mecha/working/ripley/firefighter)
 
 /datum/bounty/item/mech/firefighter
 	name = "APLU \"Firefighter\""

--- a/code/modules/cargo/bounties/mech.dm
+++ b/code/modules/cargo/bounties/mech.dm
@@ -17,6 +17,13 @@
 	name = "APLU \"Ripley\""
 	reward = 13000
 	wanted_types = list(/obj/mecha/working/ripley)
+	exclude_types = list(/obj/mecha/working/ripley/firefighter)
+
+/datum/bounty/item/mech/firefighter
+	name = "APLU \"Firefighter\""
+	reward = 18000
+	wanted_types = list(/obj/mecha/working/ripley/firefighter)
+	exclude_types = list(/obj/mecha/working/ripley)
 
 /datum/bounty/item/mech/odysseus
 	name = "Odysseus"
@@ -37,4 +44,3 @@
 	name = "Phazon"
 	reward = 50000
 	wanted_types = list(/obj/mecha/combat/phazon)
-

--- a/code/modules/cargo/bounties/security.dm
+++ b/code/modules/cargo/bounties/security.dm
@@ -26,7 +26,7 @@
 /datum/bounty/item/security/pinpointer
 	name = "Nuclear Pinpointer"
 	description = "There's a teeny-tiny itty-bitty chance CentCom may have lost a nuke disk. Can the station spare a pinpointer to help out?"
-	reward = 1500
+	reward = 4500
 	wanted_types = list(/obj/item/pinpointer/nuke)
 
 /datum/bounty/item/security/captains_spare
@@ -38,13 +38,13 @@
 /datum/bounty/item/security/hardsuit
 	name = "Security Hardsuit"
 	description = "Space pirates are heading towards CentCom! Quick! Ship a security hardsuit to aid the fight!"
-	reward = 2000
+	reward = 4000
 	wanted_types = list(/obj/item/clothing/suit/space/hardsuit/security)
 
 /datum/bounty/item/security/krav_maga
 	name = "Krav Maga Gloves"
 	description = "Chef Howerwitz of CentCom is trying to take a kung-fu Pizza out of the oven, but his mitts aren't up to the task. Ship them a pair of Krav Maga gloves to do the job right."
-	reward = 2000
+	reward = 5000
 	wanted_types = list(/obj/item/clothing/gloves/krav_maga)
 
 /datum/bounty/item/security/recharger
@@ -57,6 +57,6 @@
 /datum/bounty/item/security/sabre
 	name = "Officer's Sabre"
 	description = "A 3-hour LARP session will be held at CentCom in the upcoming months. A shipped officer's sabre would make a good prop."
-	reward = 2500
+	reward = 5000
 	wanted_types = list(/obj/item/melee/sabre)
 

--- a/code/modules/cargo/bounties/security.dm
+++ b/code/modules/cargo/bounties/security.dm
@@ -26,7 +26,7 @@
 /datum/bounty/item/security/pinpointer
 	name = "Nuclear Pinpointer"
 	description = "There's a teeny-tiny itty-bitty chance CentCom may have lost a nuke disk. Can the station spare a pinpointer to help out?"
-	reward = 4500
+	reward = 1500
 	wanted_types = list(/obj/item/pinpointer/nuke)
 
 /datum/bounty/item/security/captains_spare
@@ -38,13 +38,13 @@
 /datum/bounty/item/security/hardsuit
 	name = "Security Hardsuit"
 	description = "Space pirates are heading towards CentCom! Quick! Ship a security hardsuit to aid the fight!"
-	reward = 4000
+	reward = 2000
 	wanted_types = list(/obj/item/clothing/suit/space/hardsuit/security)
 
 /datum/bounty/item/security/krav_maga
 	name = "Krav Maga Gloves"
 	description = "Chef Howerwitz of CentCom is trying to take a kung-fu Pizza out of the oven, but his mitts aren't up to the task. Ship them a pair of Krav Maga gloves to do the job right."
-	reward = 5000
+	reward = 2000
 	wanted_types = list(/obj/item/clothing/gloves/krav_maga)
 
 /datum/bounty/item/security/recharger
@@ -57,6 +57,6 @@
 /datum/bounty/item/security/sabre
 	name = "Officer's Sabre"
 	description = "A 3-hour LARP session will be held at CentCom in the upcoming months. A shipped officer's sabre would make a good prop."
-	reward = 5000
+	reward = 2500
 	wanted_types = list(/obj/item/melee/sabre)
 

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -60,7 +60,7 @@
 
 /datum/emote/living/cough/can_run_emote(mob/user, status_check = TRUE)
 	. = ..()
-	if(user.reagents.get_reagent("menthol") || user.reagents.get_reagent("peppermint_patty"))
+	if(user.reagents && (user.reagents.get_reagent("menthol") || user.reagents.get_reagent("peppermint_patty")))
 		return FALSE
 
 /datum/emote/living/dance

--- a/html/changelogs/AutoChangeLog-pr-39379.yml
+++ b/html/changelogs/AutoChangeLog-pr-39379.yml
@@ -1,0 +1,5 @@
+author: "Denton"
+delete-after: True
+changes: 
+  - tweak: "Metastation: Spruced up the RnD circuitry lab; no gameplay changes."
+  - tweak: "Due to exemplary performance, NanoTrasen has awarded Shaft Miners with their very own bathroom, constructed at the mining station dormitories. Construction costs will be deducted from their salaries."


### PR DESCRIPTION
Original Author: 81Denton
Original PR Link: https://github.com/tgstation/tgstation/pull/39421

:cl: Denton
balance: Added new bounties and increased the bounty value of non-recoverable items, such as nuclear pinpointers and hand teles.
/:cl:

I increased the bounty value of high-risk items that can't be recovered after selling them. The reason for that is that they're hard to acquire as a cargo tech.

I mean, what Warden is going to part with his Krav Maga gloves willingly?

Item | Old price | New price
-- | -- | --
Revolver | 2000 | 4000
Hand Tele | 2000 | 5000
Pinpointer | 1500 | 4500
Sec hardsuit | 2000 | 4000
Krav maga gloves | 2000 | 5000
Sabre | 2500 | 5000

I added the following items as well:

- Firefighter APLU for 18.000 dosh - 5.000 more than a Ripley APLU since it requires three times the amount of plasteel.
- Cat tail for 3000 since we already have a lizard tail bounty.
- Cat and Liz o' Nine Tails for 4000 as a variation on the tail bounties.