### PR TITLE
[PR MIRROR]: [WIP] Adds new locations for destination taggers

### DIFF
--- a/code/_globalvars/lists/flavor_misc.dm
+++ b/code/_globalvars/lists/flavor_misc.dm
@@ -96,14 +96,26 @@ GLOBAL_LIST_INIT(scarySounds, list('sound/weapons/thudswoosh.ogg','sound/weapons
 21 Hydroponics
 22 Janitor
 23 Genetics
+24 Circuitry
+25 Toxins
+26 Dormitories
+27 Virology
+28 Xenobiology
 */
+
+//The whole system for the sorttype var is determined based on the order of this list,
+//disposals must always be 1, since anything that's untagged will automatically go to disposals, or sorttype = 1 --Superxpdude
+
+//If you don't want to fuck up disposals, add to this list, and don't change the order.
+//If you insist on changing the order, you'll have to change every sort junction to reflect the new order. --Pete
 
 GLOBAL_LIST_INIT(TAGGERLOCATIONS, list("Disposals",
 	"Cargo Bay", "QM Office", "Engineering", "CE Office",
 	"Atmospherics", "Security", "HoS Office", "Medbay",
 	"CMO Office", "Chemistry", "Research", "RD Office",
 	"Robotics", "HoP Office", "Library", "Chapel", "Theatre",
-	"Bar", "Kitchen", "Hydroponics", "Janitor Closet","Genetics"))
+	"Bar", "Kitchen", "Hydroponics", "Janitor Closet","Genetics",
+	"Circuitry", "Toxins", "Dormitories", "Virology", "Xenobiology"))
 
 GLOBAL_LIST_INIT(station_prefixes, world.file2list("strings/station_prefixes.txt") + "")
 

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -146,13 +146,7 @@
 	desc = "Used to set the destination of properly wrapped packages."
 	icon = 'icons/obj/device.dmi'
 	icon_state = "cargotagger"
-	var/currTag = 0
-	//The whole system for the sorttype var is determined based on the order of this list,
-	//disposals must always be 1, since anything that's untagged will automatically go to disposals, or sorttype = 1 --Superxpdude
-
-	//If you don't want to fuck up disposals, add to this list, and don't change the order.
-	//If you insist on changing the order, you'll have to change every sort junction to reflect the new order. --Pete
-
+	var/currTag = 0 //Destinations are stored in code\globalvars\lists\flavor_misc.dm
 	w_class = WEIGHT_CLASS_TINY
 	item_state = "electronic"
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'


### PR DESCRIPTION
Original Author: 81Denton
Original PR Link: https://github.com/tgstation/tgstation/pull/39428

:cl: Denton
tweak: New destinations have been added to destination taggers. 
/:cl:

I'm planning to add more destinations that you can mail packages to - for now it's Circuitry, Toxins, Dorms, Viro, Xenobio. Are there any others you can think of?

WIP since I want to collect ideas before I start mapping.