### PR TITLE
[PR MIRROR]: Adds Uncrossed to forceMove

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -378,6 +378,8 @@
 				oldloc.Exited(src, destination)
 				if(old_area)
 					old_area.Exited(src, destination)
+			for(var/atom/movable/AM in oldloc)
+				AM.Uncrossed(src)
 			var/turf/oldturf = get_turf(oldloc)
 			var/turf/destturf = get_turf(destination)
 			var/old_z = (oldturf ? oldturf.z : null)


### PR DESCRIPTION
Original Author: ninjanomnom
Original PR Link: https://github.com/tgstation/tgstation/pull/39434

:cl: ninjanomnom
fix: Objects picked up from tables blocking throws will no longer be forever unthrowable
/:cl:

fixes #39413 
